### PR TITLE
Don't call to Consume on errors if Error Collector is disabled

### DIFF
--- a/internal_txn.go
+++ b/internal_txn.go
@@ -215,6 +215,9 @@ func (txn *txn) End() error {
 		e := internal.TxnErrorFromPanic(r)
 		e.Stack = internal.GetStackTrace(0)
 		txn.noticeErrorInternal(e)
+		if !txn.Config.ErrorCollector.Enabled {
+			txn.ignore = true
+		}
 	}
 
 	txn.stop = time.Now()


### PR DESCRIPTION
Don't call to Consume (in  internal_txt:End() ) on errors if Error Collector is disabled
